### PR TITLE
change sf::RenderWindow name

### DIFF
--- a/examples/simple_window.cpp
+++ b/examples/simple_window.cpp
@@ -2,7 +2,7 @@
 
 int main()
 {
-    sf::RenderWindow window(sf::VideoMode(200, 200), "SFML works!");
+    sf::RenderWindow window(sf::VideoMode(200, 200), "i3Float");
     sf::CircleShape  shape(100.f);
     shape.setFillColor(sf::Color::Green);
 


### PR DESCRIPTION
To get a floating window in i3 I need to rename Window "i3Float".
In due time maybe we have to find other solution..  